### PR TITLE
Add homepage metadata in pyproject config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ line-length = 119
 module = "rnanorm"
 author = "Genialis, Inc."
 author-email = "miha@genialis.com"
+home-page="https://github.com/genialis/rnaseq-normalization/"
 description-file = "README.md"
 requires=[
     "pandas~=1.0.1",


### PR DESCRIPTION
Pypi archive upload requires homepage is set.